### PR TITLE
fix: API RouteでのCookie設定をNextResponse.cookiesに修正

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -71,9 +71,7 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    AuthService.setAuthCookies(accessToken, refreshToken)
-
-    return NextResponse.json({
+    const response = NextResponse.json({
       user: {
         id: user.id,
         email: user.email,
@@ -82,6 +80,25 @@ export async function POST(request: NextRequest) {
       },
       accessToken,
     })
+
+    // Set cookies directly on the response
+    response.cookies.set('accessToken', accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 15 * 60, // 15 minutes
+      path: '/',
+    })
+
+    response.cookies.set('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 7 * 24 * 60 * 60, // 7 days
+      path: '/',
+    })
+
+    return response
   } catch (error) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -12,9 +12,13 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    AuthService.clearAuthCookies()
+    const response = NextResponse.json({ message: 'ログアウトしました' })
+    
+    // Clear cookies directly on the response
+    response.cookies.delete('accessToken')
+    response.cookies.delete('refreshToken')
 
-    return NextResponse.json({ message: 'ログアウトしました' })
+    return response
   } catch (error) {
     console.error('Logout error:', error)
     return NextResponse.json(

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -71,10 +71,7 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    // Set new cookies
-    AuthService.setAuthCookies(newAccessToken, newRefreshToken)
-
-    return NextResponse.json({
+    const response = NextResponse.json({
       accessToken: newAccessToken,
       user: {
         id: user.id,
@@ -83,6 +80,25 @@ export async function POST(request: NextRequest) {
         role: user.role,
       },
     })
+
+    // Set cookies directly on the response
+    response.cookies.set('accessToken', newAccessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 15 * 60, // 15 minutes
+      path: '/',
+    })
+
+    response.cookies.set('refreshToken', newRefreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 7 * 24 * 60 * 60, // 7 days
+      path: '/',
+    })
+
+    return response
   } catch (error) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -56,9 +56,7 @@ export async function POST(request: NextRequest) {
       },
     })
 
-    AuthService.setAuthCookies(accessToken, refreshToken)
-
-    return NextResponse.json({
+    const response = NextResponse.json({
       user: {
         id: user.id,
         email: user.email,
@@ -67,6 +65,25 @@ export async function POST(request: NextRequest) {
       },
       accessToken,
     })
+
+    // Set cookies directly on the response
+    response.cookies.set('accessToken', accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 15 * 60, // 15 minutes
+      path: '/',
+    })
+
+    response.cookies.set('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 7 * 24 * 60 * 60, // 7 days
+      path: '/',
+    })
+
+    return response
   } catch (error) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(


### PR DESCRIPTION
- AuthService.setAuthCookies/clearAuthCookiesの使用を停止
- Next.js API Route内でcookies()を直接呼び出すことができない問題を解決
- ログイン、ログアウト、ユーザー登録、トークン更新の全てのルートで修正
- NextResponseオブジェクトのcookiesメソッドを使用してCookieを適切に設定

🤖 Generated with [Claude Code](https://claude.ai/code)